### PR TITLE
🐛 [Fix] #21 -  배포에서 슬라이드1 깨지는문제

### DIFF
--- a/src/components/main/TestSlide.jsx
+++ b/src/components/main/TestSlide.jsx
@@ -16,7 +16,14 @@ const TestSlide = () => {
       </SlideContent>
       <ImgFlexDiv>
         <SlideImg>
-          <img src={slide1Png} alt="슬라이드1이미지" />
+          <img
+            src={slide1Png}
+            style={{
+              width: "auto",
+              height: "133px",
+              display: "block",
+            }}
+          />
         </SlideImg>
       </ImgFlexDiv>
     </Wrapper>


### PR DESCRIPTION
## 🔍 What is the PR?

개발자도구로 봤을때는 안깨지는데 배포해보니 슬라이드1이 깨져서 수정해봅니다,,, 아마 이미지를 4x로 변경하면서 깨진거같은데 자세한 이유는 모르겠음 

## 📸 Screenshot
![image](https://github.com/user-attachments/assets/9d319ed5-4cec-4492-b2ab-6104943db6e5)
현재 깨지는 상태. 배포후 수정됐는지 확인해볼예정

이미지태그에 인라인으로 이미지 크기 설정함 
## ✅ Check List

- [ ] Merge 하는 브랜치가 올바른가?
- [ ] PR과 관련없는 변경사항이 없는가?
- [ ] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

-  #21 
