### PR TITLE
🐛 [Fix] #76 -일반로그인 API에러 수정완

### DIFF
--- a/src/hooks/useKakaoAuth.jsx
+++ b/src/hooks/useKakaoAuth.jsx
@@ -4,7 +4,7 @@ import {
   createContext,
   useContext,
 } from "react";
-import axios from "../apis/axiosInstance";
+import axios from "@apis/axiosInstance";
 
 // KakaoAuthContext 생성: 로그인 상태를 관리하는 Context
 const KakaoAuthContext = createContext();

--- a/src/pages/loginPage/LoginPage.jsx
+++ b/src/pages/loginPage/LoginPage.jsx
@@ -2,7 +2,8 @@ import React, { useState } from "react";
 import * as S from "./LoginPage.styled";
 import Logo from "@assets/icons/Logo.svg";
 import { useCustomNavigate } from "@hooks/useCustomNavigate";
-import axios from "axios";
+
+import axiosInstance from "@apis/axiosInstance"; // ✅ axiosInstance 사용
 
 export const LoginPage = () => {
   const { goTo } = useCustomNavigate();
@@ -19,34 +20,60 @@ export const LoginPage = () => {
     }
 
     try {
-      let refreshToken = localStorage.getItem("refresh");
-      if (!refreshToken) refreshToken = null; // ✅ refresh_token이 없을 경우 null 처리
+      let refreshToken = localStorage.getItem("refresh") || null;
 
-      const response = await axios.post(`${import.meta.env.VITE_BASE_URL}/api/accounts/login`, {
-        email,
-        password,
-        refresh_token: refreshToken, // ✅ 로그인 요청 시 refresh_token 추가
-      });
+      // ✅ 기존 axios 대신 axiosInstance 사용
+      const response = await axiosInstance.post(
+        "/api/accounts/login",
+        {
+          email,
+          password,
+          refresh_token: refreshToken,
+        }
+      );
 
-      const { access_token, refresh_token: newRefreshToken } = response.data;
+      console.log("로그인 응답 데이터:", response.data);
+      // ✅ 응답 구조 수정 (API 명세서에 맞게)
+      const accessToken = response.data.token.access;
+      const newRefreshToken = response.data.token.refresh;
 
-      localStorage.setItem("access", access_token);
+      if (!accessToken || !newRefreshToken) {
+        throw new Error("토큰이 반환되지 않았습니다.");
+      }
+      // ✅ 토큰을 localStorage에 저장
+      localStorage.setItem("access", accessToken);
       localStorage.setItem("refresh", newRefreshToken);
 
+      console.log(
+        "저장된 access token:",
+        localStorage.getItem("access")
+      );
+      console.log(
+        "저장된 refresh token:",
+        localStorage.getItem("refresh")
+      );
+
       console.log("로그인 성공:", response.data);
-      goTo("/main"); // 로그인 성공 시 메인 페이지로 이동
+      // ✅ axiosInstance의 Authorization 헤더 즉시 업데이트
+      axiosInstance.defaults.headers.common[
+        "Authorization"
+      ] = `Bearer ${accessToken}`;
+
+      // ✅ 새로고침 없이 상태 업데이트 보장
+
+      goTo("/main");
     } catch (err) {
-      console.error("로그인 오류:", err.response?.data || err.message);
+      console.error(
+        "로그인 오류:",
+        err.response?.data || err.message
+      );
       setIsError(true);
       setErrorMessage(err.response?.data?.error || "로그인 실패");
     }
   };
-
   return (
     <S.Wrapper>
-      <S.Header onClick={() => goTo("/main")}>
-        둘러보기
-      </S.Header>
+      <S.Header onClick={() => goTo("/main")}>둘러보기</S.Header>
       <S.LogoWrapper>
         <S.Logo src={Logo} alt="나눠주개 로고" />
       </S.LogoWrapper>

--- a/src/pages/loginPage/LoginPage.styled.js
+++ b/src/pages/loginPage/LoginPage.styled.js
@@ -20,14 +20,16 @@ export const Header = styled.div`
   justify-content: flex-end;
   margin-top: 6px;
   color: ${({ theme }) => theme.colors.mainColor};
-  font-family: ${({ theme }) => theme.fonts.SUITSemiBold["font-family"]};
+  font-family: ${({ theme }) =>
+    theme.fonts.SUITSemiBold["font-family"]};
 `;
 export const TitleInfo = styled.div`
   display: flex;
   width: 100%;
   font-size: 14px;
   color: ${({ theme }) => theme.colors.mainColor};
-  font-family: ${({ theme }) => theme.fonts.SUITMedium["font-family"]};
+  font-family: ${({ theme }) =>
+    theme.fonts.SUITMedium["font-family"]};
   margin-left: 70px;
 `;
 export const InputBox = styled.input`
@@ -38,7 +40,8 @@ export const InputBox = styled.input`
   align-items: center;
 
   border-radius: 20px;
-  border: 1px solid ${(props) => (props.isError ? "#ff6969" : "#e7e8eb")};
+  border: 1px solid
+    ${(props) => (props.$isError ? "#ff6969" : "#e7e8eb")};
   background: #fff;
 
   &::placeholder {
@@ -51,7 +54,8 @@ export const InputBox = styled.input`
   }
 
   &:focus {
-    border: 1px solid ${(props) => (props.isError ? "#ff6969" : "#e7e8eb")};
+    border: 1px solid
+      ${(props) => (props.$isError ? "#ff6969" : "#e7e8eb")};
     outline: none;
   }
 `;
@@ -79,17 +83,14 @@ export const Btn = styled.button`
   justify-content: center;
   align-items: center;
   width: 85.33%;
-  /* min-width: 300px; */
   height: 53px;
   border-radius: 50px;
 
   font-size: 16px;
+  font-family: ${({ theme }) => theme.fonts.SUITSemiBold};
 
-  font-family: ${({ theme }) => theme.fonts.SUITSemiBold["font-family"]};
-
-  background-color: ${({ type }) =>
-    type === "kakao" ? "#FFE812" : ({ theme }) => theme.colors.mainColor};
-  color: ${({ type }) => (type === "kakao" ? "#000000" : "#ffffff")};
+  background-color: ${({ theme }) => theme.colors.mainColor};
+  color: #ffffff;
 `;
 
 export const SignUp = styled.div`
@@ -100,7 +101,8 @@ export const SignUp = styled.div`
 
   font-size: 12px;
   color: #2a2a2a;
-  font-family: ${({ theme }) => theme.fonts.SUITMedium["font-family"]};
+  font-family: ${({ theme }) =>
+    theme.fonts.SUITMedium["font-family"]};
 `;
 
 export const SignUpLink = styled(Link)`
@@ -108,5 +110,6 @@ export const SignUpLink = styled(Link)`
   margin-left: 7px;
   text-decoration: none;
   color: ${({ theme }) => theme.colors.mainColor};
-  font-family: ${({ theme }) => theme.fonts.SUITExtraBold["font-family"]};
+  font-family: ${({ theme }) =>
+    theme.fonts.SUITExtraBold["font-family"]};
 `;

--- a/src/pages/loginPage/WelcomePage.jsx
+++ b/src/pages/loginPage/WelcomePage.jsx
@@ -35,7 +35,7 @@ export const WelcomePage = () => {
         </S.Btn>
         <S.SignUp>
           아직 회원이 아니신가요?
-          <S.SignUpLink to="/main">회원가입하기</S.SignUpLink>
+          <S.SignUpLink to="/signup">회원가입하기</S.SignUpLink>
         </S.SignUp>
       </S.BtnWrapper>
     </S.Wrapper>


### PR DESCRIPTION
## 🔍 What is the PR?

일반로그인을 하면 마이페이지에서 회원이메일 정보가 안불러와지고 엑세스와 리프레시토큰이 로컬스토리지에 저장안되는 에러 해결했습니다. 

## 📸 Screenshot

잘불러와집니다
![Uploading image.png…]()


## 📢 Notices

api명세서에서 명세서마다 엑세스토큰과 리프레시토큰 변수명이 다른경우가 있는데 이를 고려해서 프론트에서 연결할때도 신경써야될듯합니다! 이거때문에 오류났던거같아요 

```
     axiosInstance.defaults.headers.common[
        "Authorization"
      ] = `Bearer ${accessToken}`;

```
로그인페이지에서 로그인성공후 바로 인증헤더 업데이트 시켜서 401에러 안나게 했습니다. 

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #76
