### PR TITLE
[✨Feature]/#113 이미지 2장 이상인 경우 한장씩만 보이고 스크롤 되도록 설정, 댓글 옆 이미지 찌그러짐 수정

### DIFF
--- a/src/components/community/Comment.jsx
+++ b/src/components/community/Comment.jsx
@@ -47,8 +47,11 @@ const Image = styled.div`
     display: flex;
     align-items: center;
     justify-content: center;
+    aspect-ratio: 1 /1;
+    width: 80%;
     img{
-        width: 80%;
+        width: 100%;
+        height: 100%;
         border-radius: 38px;
         background: url(<path-to-image>) lightgray 50% / cover no-repeat;
         box-shadow: 0px 1px 2px 0px rgba(0, 0, 0, 0.15);

--- a/src/pages/communityPage/CommunityDetail.styled.js
+++ b/src/pages/communityPage/CommunityDetail.styled.js
@@ -188,12 +188,22 @@ export const Write = styled.div`
 export const MainImg = styled.div`
   display: flex;
   width: 100%;
-  justify-content: center;
+  max-width: 181px; 
+  margin: 0 auto;
+  justify-content: flex-start;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory; // 가로 방향 스크롤에서 무조건 특정 요소에서 멈추도록 설정
+
   img {
     width: 181px;
     height: 111px;
     flex-shrink: 0;
     border-radius: 6px;
+    scroll-snap-align: start;
+  }
+
+  &::-webkit-scrollbar {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## 🔍 What is the PR?

- 이미지 2장 이상인 경우 한장씩만 보이고 스크롤 되도록 설정
- 댓글 옆 이미지 찌그러짐 수정

## 📸 Screenshot

<img width="324" alt="스크린샷 2025-03-20 오후 2 12 57" src="https://github.com/user-attachments/assets/df3e23b9-9012-4b8d-84c5-cf6efdcbf3ef" />
<img width="324" alt="스크린샷 2025-03-20 오후 2 13 08" src="https://github.com/user-attachments/assets/cd023162-16ff-484e-96c7-517a6c95a36b" />
<img width="324" alt="스크린샷 2025-03-20 오후 2 12 07" src="https://github.com/user-attachments/assets/a1758c6b-e3b8-4a05-8d66-a1fe6d24ec18" />

## 📍 PR Point

scroll-snap-type: x mandatory; 
-> 이거 사용하면 가로 방향 스크롤에서 무조건 특정 요소에서 멈추도록 설정할 수 있답니다!

## 📢 Notices

## ✅ Check List

- [x] Merge 하는 브랜치가 올바른가?
- [x] PR과 관련없는 변경사항이 없는가?
- [x] 내 코드에 대한 자기 검토가 되었는가?

## 💭 Related Issues

- #113 
